### PR TITLE
debug BMS CAN messages for first {x} ms, default at 20s

### DIFF
--- a/Firmware/Main/config.h
+++ b/Firmware/Main/config.h
@@ -34,6 +34,8 @@
 
 #define CONFIG_LOG_COUNT 7
 
+#define CONFIG_DEBUG_CAN_MS (20 * 1000)
+
 //#define CONFIG_TEST_SCREEN_DATA 1
 
 #endif // _CONFIG_H


### PR DESCRIPTION
@mchen26
I did not see anything sus in the CAN message handling for the BMS messages. Can add these changes to print out to the serial for first 20s to get more info

Once you get a trace feel free to send it to me